### PR TITLE
Move QIF export logic from Operation type

### DIFF
--- a/src/TempOpBll/Exporters/QifExporter.cs
+++ b/src/TempOpBll/Exporters/QifExporter.cs
@@ -1,0 +1,29 @@
+﻿using System.Globalization;
+using TempOpBll.Interfaces;
+using TempOpBll.Models;
+
+namespace TempOpBll.Exporters
+{
+
+    public class QifExporter : IExporter<Operation>
+    {
+        /// <summary>
+        /// Exports the specified operation to a QIF string representation.
+        /// </summary>
+        /// <param name="input">The operation object to be exported. Cannot be null.</param>
+        /// <returns>A string representation of the operation in QIF format.</returns>
+        public string Export(Operation op)
+        {
+            if (op == null) throw new ArgumentNullException(nameof(op));
+
+            var date = op.Date.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture);
+            var amount = op.Amount.ToString("-0.00", CultureInfo.InvariantCulture);
+            var label = op.Quantity.HasValue ? $"{op.Label} ×{op.Quantity}" : op.Label;
+            var memo = !string.IsNullOrWhiteSpace(op.Comment)
+                ? $"{op.Category} - {op.Comment}"
+                : op.Category;
+
+            return $"D{date}{Environment.NewLine}T{amount}{Environment.NewLine}P{label}{Environment.NewLine}M{memo}{Environment.NewLine}^";
+        }
+    }
+}

--- a/src/TempOpBll/Interfaces/IExporter.cs
+++ b/src/TempOpBll/Interfaces/IExporter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TempOpBll.Interfaces
+{
+    public interface IExporter<T>
+    {
+        /// <summary>
+        /// Exports the specified input to a string representation.
+        /// </summary>
+        /// <param name="input">The input object to be exported. Cannot be null.</param>
+        /// <returns>A string representation of the input object.</returns>
+        string Export(T input);
+    }
+}

--- a/src/TempOpBll/Models/Operation.cs
+++ b/src/TempOpBll/Models/Operation.cs
@@ -23,22 +23,5 @@ namespace TempOpBll.Models
             var commentText = string.IsNullOrWhiteSpace(Comment) ? "" : $" ({Comment})";
             return $"{Category} {qtyText}{Label}{commentText} {Amount:0.00}€";
         }
-
-        /// <summary>
-        /// Converts this operation into a QIF (Quicken Interchange Format) string.
-        /// Suitable for exporting to finance management tools that support QIF format.
-        /// </summary>
-        /// <returns>A multi-line string representing the operation in QIF format.</returns>
-        public string ToQifString()
-        {
-            string date = Date.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture);
-            string amount = Amount.ToString("-0.00", CultureInfo.InvariantCulture);
-            string label = Quantity.HasValue ? $"{Label} ×{Quantity}" : Label;
-            string memo = !string.IsNullOrWhiteSpace(Comment)
-                ? $"{Category} - {Comment}"
-                : Category;
-
-            return $"D{date}{Environment.NewLine}T{amount}{Environment.NewLine}P{label}{Environment.NewLine}M{memo}{Environment.NewLine}^";
-        }
     }
 }

--- a/test/TempOpBllTests/ModelTests/OperationModelTests.cs
+++ b/test/TempOpBllTests/ModelTests/OperationModelTests.cs
@@ -1,6 +1,6 @@
 using System.Globalization;
-using System.Reflection.Emit;
-using System.Xml.Linq;
+using TempOpBll.Exporters;
+using TempOpBll.Interfaces;
 using TempOpBll.Models;
 
 namespace TempOpBllTests.ModelTests
@@ -122,9 +122,10 @@ MMisc:Pets
         public void ToQifString_ShouldReturnQifFormattedOutput(Operation operation, string expectedOutput)
         {
             //Arrange - n/a
+            IExporter<Operation> exporter = new QifExporter();
 
             //Act
-            string output = operation.ToQifString();
+            string output = exporter.Export(operation);
 
             //Assert
             Assert.Equal(expectedOutput, output);
@@ -133,6 +134,7 @@ MMisc:Pets
         [Fact]
         public void ToQifString_ShouldUseInvariantCulture_ForAmountFormatting()
         {
+            // Arrange
             var originalCulture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
 
@@ -144,8 +146,12 @@ MMisc:Pets
                 Category = "Test",
             };
 
-            string result = op.ToQifString();
+            IExporter<Operation> exporter = new QifExporter();
 
+            // Act
+            string result = exporter.Export(op);
+
+            // Assert
             Assert.Contains("T-123.45", result);
 
             Thread.CurrentThread.CurrentCulture = originalCulture;


### PR DESCRIPTION
Created an `IExporter<T>` interface so that we could export to different formats but mostly to extract the logic from the `Operation` type.